### PR TITLE
rc3, not rc2

### DIFF
--- a/var/build_prop.json
+++ b/var/build_prop.json
@@ -1,7 +1,7 @@
 {	
 	"properties": [
 		"PyT-Kernel_21-16_080421_userdebug",
-		"0.0.1rc2",
+		"0.0.1rc3",
 		["pyt2"],
 		"../mod",
 		"pyt2",


### PR DESCRIPTION
because changelogs:
"... -> PyT 0.0.1rc3"